### PR TITLE
Add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,61 @@
+name: Terraform module defect
+description: Report a reproducible problem with the Proxmox SDN module.
+title: "[bug] "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Do not include API tokens, SSH keys, private addresses, customer data, or unredacted Terraform output.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Terraform validation or plan
+        - Proxmox SDN objects
+        - Host L3, NAT, or routing
+        - DHCP or dnsmasq
+        - Examples
+        - Documentation
+    validations:
+      required: true
+  - type: input
+    id: reference
+    attributes:
+      label: Relevant reference
+      description: Module version, example path, input, output, or script involved.
+      placeholder: v0.1.5, examples/basic, host_reconcile_nonce, enable_dhcp
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+    validations:
+      required: true
+  - type: textarea
+    id: observed
+    attributes:
+      label: Observed behaviour
+      description: Include the exact error or result, with sensitive data removed.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Run terraform init -backend=false
+        2. Run terraform plan ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include Terraform version, Proxmox VE version, provider version, module version or commit, and whether this was validate-only, plan-only, or live apply.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security report
+    url: mailto:security@hybridops.tech
+    about: Report suspected vulnerabilities privately. Do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/improvement.yml
+++ b/.github/ISSUE_TEMPLATE/improvement.yml
@@ -1,0 +1,48 @@
+name: Focused improvement
+description: Propose a bounded improvement to the Proxmox SDN module.
+title: "[improvement] "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Direct pull requests are welcome for contained improvements. Use this form when the change needs agreement before implementation.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Module inputs or validation
+        - Outputs or downstream integration
+        - Examples
+        - Host-side scripts
+        - CI or release workflow
+        - Documentation
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: Describe the operator or contributor problem this would solve.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: Keep the proposal bounded. Link inputs, examples, scripts, or docs where useful.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: What should be demonstrably true when the change is complete?
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution
+      options:
+        - label: I can work on a pull request for this change.

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,40 @@
+name: Usage question or compatibility check
+description: Ask a focused question about usage, examples, compatibility, or safe adoption.
+title: "[question] "
+labels:
+  - question
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for focused questions. Do not paste API tokens, SSH keys, private IP plans, or unredacted Terraform output.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - First example or quickstart
+        - Proxmox VE or provider compatibility
+        - Host-routed versus edge-routed mode
+        - Brownfield adoption
+        - DHCP, NAT, or static routes
+        - Registry or Git source usage
+    validations:
+      required: true
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: Ask the specific thing you need clarified.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Include versions, example path, or planned usage if known. Say if this is based on docs review rather than a live run.
+  - type: textarea
+    id: checked
+    attributes:
+      label: What you checked
+      description: Link the README section, example, issue, or command you already reviewed.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Summary
+
+<!-- What problem does this change solve? Link the issue if one exists. -->
+
+Closes #
+
+## Validation
+
+<!-- List the checks or commands you ran, for example terraform fmt -recursive, terraform init -backend=false, terraform validate. -->
+
+## Scope
+
+- [ ] This pull request is focused on one change.
+- [ ] I have not included API tokens, SSH keys, private addresses, or customer data.
+- [ ] I updated documentation, examples, or tests where the change needs them.
+- [ ] I noted whether this was validate-only, plan-only, or tested with a live Proxmox VE run.


### PR DESCRIPTION
## Summary

Adds GitHub issue forms for SDN module defects, focused improvements, and usage or compatibility questions. Also adds a PR template so future changes have a consistent summary, validation, scope, and closure shape.

Closes #8

## Validation

- Parsed all new issue template YAML files with PyYAML.
- Checked generated files for trailing whitespace and final newlines.

## Scope

- [x] This pull request is focused on one change.
- [x] I have not included API tokens, SSH keys, private addresses, or customer data.
- [x] I updated documentation, examples, or tests where the change needs them.
- [x] I noted whether this was validate-only, plan-only, or tested with a live Proxmox VE run.