### PR TITLE
Validate Terraform examples in CI

### DIFF
--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -27,19 +27,44 @@ jobs:
       - name: Check formatting
         run: terraform fmt -check -recursive
 
-  validate:
-    name: validate (${{ matrix.path }})
+  validate-module:
+    name: validate module
+    runs-on: ubuntu-latest
+    needs: fmt
+    defaults:
+      run:
+        working-directory: .
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: "1.13.4"
+
+      - name: Init module
+        run: terraform init -backend=false -input=false
+
+      - name: Validate module
+        run: terraform validate -no-color
+
+  validate-examples:
+    name: validate example (${{ matrix.name }})
     runs-on: ubuntu-latest
     needs: fmt
     strategy:
       fail-fast: false
       matrix:
-        path:
-          - "."
-          - "examples/basic"
-          - "examples/homelab-six-vlans"
-          - "examples/multi-node"
-          - "examples/no-dhcp"
+        include:
+          - name: basic
+            path: examples/basic
+          - name: homelab-six-vlans
+            path: examples/homelab-six-vlans
+          - name: multi-node
+            path: examples/multi-node
+          - name: no-dhcp
+            path: examples/no-dhcp
     defaults:
       run:
         working-directory: ${{ matrix.path }}
@@ -52,8 +77,8 @@ jobs:
         with:
           terraform_version: "1.13.4"
 
-      - name: Init
+      - name: Init example
         run: terraform init -backend=false -input=false
 
-      - name: Validate
+      - name: Validate example
         run: terraform validate -no-color


### PR DESCRIPTION
Closes #15

This updates the Terraform validation workflow so CI checks both the root module and each supported example configuration.

## What changed

- Kept `terraform fmt -check -recursive` as a repo-wide formatting check
- Validated the root module in its own CI job
- Validated each example in a separate matrix job:
  - `examples/basic`
  - `examples/homelab-six-vlans`
  - `examples/multi-node`
  - `examples/no-dhcp`
- Renamed the example job output so GitHub Actions clearly shows which example failed

## Validation

Validated by the GitHub Actions workflow before merge.