### PR TITLE
Clean up example metadata and validation guidance

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -31,7 +31,14 @@ From the repository root:
 
 3. Edit `terraform.tfvars` to match your environment.
 
-4. Apply:
+4. Validate without touching live infrastructure:
+
+   ```bash
+   terraform init -backend=false -input=false
+   terraform validate -no-color
+   ```
+
+5. Plan and apply when ready:
 
    ```bash
    terraform init

--- a/examples/homelab-six-vlans/terraform.tfvars.example
+++ b/examples/homelab-six-vlans/terraform.tfvars.example
@@ -1,5 +1,5 @@
-# file: examples/basic/terraform.tfvars.example
-# purpose: Example inputs for a single-node Proxmox SDN deployment
+# file: examples/homelab-six-vlans/terraform.tfvars.example
+# purpose: Example inputs for a six-VLAN Proxmox SDN reference layout
 
 # Proxmox API configuration
 proxmox_url      = "https://<PROXMOX-IP>:8006/api2/json"

--- a/examples/no-dhcp/outputs.tf
+++ b/examples/no-dhcp/outputs.tf
@@ -12,6 +12,6 @@ output "vnets" {
 }
 
 output "subnets" {
-  description = "Created SDN subnets with DHCP configuration."
+  description = "Created SDN subnets."
   value       = module.sdn.subnets
 }

--- a/examples/no-dhcp/terraform.tfvars.example
+++ b/examples/no-dhcp/terraform.tfvars.example
@@ -1,5 +1,5 @@
-# file: examples/basic/terraform.tfvars.example
-# purpose: Example inputs for a single-node Proxmox SDN deployment
+# file: examples/no-dhcp/terraform.tfvars.example
+# purpose: Example inputs for a no-DHCP Proxmox SDN deployment
 
 # Proxmox API configuration
 proxmox_url      = "https://<PROXMOX-IP>:8006/api2/json"


### PR DESCRIPTION
## Summary

- fix stale `terraform.tfvars.example` headers in the example directories
- update the no-DHCP output description so it does not imply DHCP is configured
- add a short validate-only note for checking examples before live plan/apply

## Validation

- ran `terraform fmt -recursive`
- ran `terraform init -backend=false -input=false`
- ran `terraform validate -no-color`

Closes #20 
