### PR TITLE
Run Terraform tests in CI

### DIFF
--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Validate module
         run: terraform validate -no-color
 
+      - name: Test module
+        run: terraform test -no-color
+
   validate-examples:
     name: validate example (${{ matrix.name }})
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Run the native Terraform test suite after module validation so test failures block the validation job.

This prepares CI for the module tests introduced through #26. Formatting and example validation are unchanged.

## Validation

- `terraform fmt -check -recursive`
- `terraform init -backend=false -input=false -no-color`
- `terraform validate -no-color`
- `terraform test -no-color`

Closes #27
