### PR TITLE
Support multi-node SDN zone membership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Optional `proxmox_nodes` input for assigning one SDN zone and its VNets to
+  several Proxmox cluster nodes. Multi-node membership is edge-routed; host-side
+  L3, SNAT, DHCP, and static routes remain single-host features.
 - `host_static_routes` input for host-routed Proxmox SDN deployments that need
   selected upstream or cloud prefixes routed through a separate on-prem edge.
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ hybridops-platform/infra/terraform/live-v1/onprem/proxmox/core/00-foundation/net
 ## Features
 
 - Creates a VLAN-backed **SDN zone** on a Proxmox bridge.
+- Supports one zone across several Proxmox nodes through optional `proxmox_nodes` membership.
 - Manages **VNets** and **subnets** via a single `vnets` map.
 - Optional **host L3**: assigns gateway IPs on VNet bridge interfaces.
 - Optional **SNAT**: per-subnet masquerade to an uplink interface.
@@ -179,7 +180,8 @@ Typical reference layout (six VLANs):
 |----------------|--------|----------|-------------|
 | `zone_name`    | string | yes      | SDN zone ID (≤ 8 chars, lowercase, no dashes – Proxmox SDN rules). |
 | `zone_bridge`  | string | no       | Proxmox bridge to attach the SDN zone to (default: `vmbr0`). |
-| `proxmox_node` | string | yes      | Proxmox node name (for example `pve` or `hybridhub`). |
+| `proxmox_node` | string | yes, unless `proxmox_nodes` is set | Legacy single Proxmox node name (for example `pve` or `hybridhub`). |
+| `proxmox_nodes` | list(string) | no | Cluster node names for shared SDN zone membership. Takes precedence over `proxmox_node`. |
 | `proxmox_host` | string | yes      | Proxmox host (IP or DNS) used over SSH for host-side scripts. |
 | `vnets`        | map    | yes      | Map of VNets and subnets (see structure below). |
 
@@ -199,6 +201,8 @@ Typical reference layout (six VLANs):
 > The module enforces that `enable_dhcp = true` requires `enable_host_l3 = true`, so dnsmasq can bind to VNet interfaces safely.
 >
 > `host_static_routes` also requires `enable_host_l3 = true`, because the Proxmox host must be the effective gateway for guests before these routes can influence downstream traffic.
+>
+> A `proxmox_nodes` list containing more than one node requires `enable_host_l3 = false`. Cluster-wide membership is currently edge-routed; host L3, SNAT, DHCP, and static routes remain single-host features.
 
 ### Recovery / self-heal (host-side drift)
 
@@ -385,6 +389,28 @@ and routing/DHCP are delegated to the actual edge or network services layer.
 Recommended production posture:
 - let **VyOS or the edge tier** own north-south routing and egress
 - keep Proxmox SDN focused on segmentation unless you explicitly want host-routed subnets
+
+### Cluster-wide zone membership
+
+Use `proxmox_nodes` when the same SDN zone and VNets must be available across a
+Proxmox cluster:
+
+```hcl
+proxmox_nodes = ["pve1", "pve2", "pve3"]
+proxmox_host  = "192.0.2.10"
+
+enable_host_l3 = false
+enable_snat    = false
+enable_dhcp    = false
+```
+
+When `proxmox_nodes` is empty, the module retains the existing
+`proxmox_node` behaviour. When it is set, the list takes precedence. Multi-node
+membership changes only the SDN zone's `nodes` property; it does not distribute
+SSH-based host configuration across the cluster.
+
+See [`examples/multi-node`](examples/multi-node) for a complete edge-routed
+cluster example.
 
 ## Brownfield adoption
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,7 +11,7 @@ Each example directory also includes its own `README.md` so the Terraform Regist
 | `basic` | Single VNet with DHCP (minimal configuration). |
 | `homelab-six-vlans` | Six VLAN reference layout for segmented environments. |
 | `no-dhcp` | Static IP networking without DHCP. |
-| `multi-node` | Multi-node pattern (planned). |
+| `multi-node` | Shared edge-routed SDN zone across several Proxmox cluster nodes. |
 
 ## Run an example
 

--- a/examples/multi-node/README.md
+++ b/examples/multi-node/README.md
@@ -1,22 +1,27 @@
 # Multi-Node Example
 
-Current single-node implementation shaped around a future Proxmox cluster SDN pattern.
-
-The active configuration manages node 1 only. The commented node 2 block documents the intended direction for a later multi-node module release.
+Assign one Proxmox SDN zone and its VNets to several cluster nodes while routing
+and DHCP remain in a separate edge or network-services layer.
 
 ## What it creates
 
-- SDN zone `clust01` on bridge `vmbr0`.
+- SDN zone `clust01` on bridge `vmbr0` across the names in `proxmox_nodes`.
 - VNet `vclst01m` using VLAN ID `200`.
-- Subnet `10.200.0.0/24` with gateway `10.200.0.1`.
-- DHCP range `10.200.0.120` through `10.200.0.220`.
-- SNAT through uplink interface `vmbr0`.
+- Subnet `10.200.0.0/24` with the edge-owned gateway `10.200.0.1`.
+
+The module does not configure host L3, SNAT, DHCP, or static routes in this
+example. Those features still target one `proxmox_host` and are not supported
+with a multi-node membership list.
+
+`proxmox_host` selects one reachable cluster node for SSH-based SDN apply and
+status operations. It does not make that node the gateway.
 
 ## Usage
 
 ```bash
 cp terraform.tfvars.example terraform.tfvars
-terraform init
+terraform init -backend=false
+terraform validate
 terraform plan
 terraform apply
 ```
@@ -27,14 +32,9 @@ Edit `terraform.tfvars` before running `terraform plan`.
 
 - `proxmox_url`
 - `proxmox_token`
-- `proxmox_node1`
-- `proxmox_host_node1`
-
-## Optional Variables
-
-- `proxmox_node2`: Placeholder for the planned secondary node example.
-- `proxmox_host_node2`: Placeholder for the planned secondary node SSH host.
+- `proxmox_nodes`
+- `proxmox_host`
 
 ## Outputs
 
-- `sdn_nodes`: Aggregated SDN outputs for the active node configuration.
+- `sdn_cluster`: Zone, VNet, and subnet values for the shared cluster SDN.

--- a/examples/multi-node/main.tf
+++ b/examples/multi-node/main.tf
@@ -1,5 +1,5 @@
 # file: examples/multi-node/main.tf
-# purpose: Single-node SDN example for a future Proxmox cluster zone
+# purpose: Shared edge-routed SDN zone across a Proxmox cluster
 # maintainer: HybridOps
 
 terraform {
@@ -19,40 +19,30 @@ provider "proxmox" {
   insecure  = var.proxmox_insecure
 }
 
-# Current module behaviour: single Proxmox node per SDN zone.
-# This example uses a "cluster-zone" VNet design on node1.
-module "sdn_node1" {
+module "sdn_cluster" {
   source = "../.."
 
   # SDN zone ID must be <= 8 chars, lowercase, no dashes
   zone_name   = "clust01"
   zone_bridge = "vmbr0"
 
-  proxmox_node = var.proxmox_node1
-  proxmox_host = var.proxmox_host_node1
+  proxmox_nodes = var.proxmox_nodes
+  proxmox_host  = var.proxmox_host
 
-  # Host-level services
-  enable_host_l3   = true
-  enable_snat      = true
-  uplink_interface = "vmbr0"
-  enable_dhcp      = true
-
-  dns_domain = "hybridops.local"
-  dns_lease  = "24h"
+  # Multi-node membership is edge-routed in this release. Gateway, SNAT,
+  # DHCP, and static routes remain outside this module invocation.
+  enable_host_l3 = false
+  enable_snat    = false
+  enable_dhcp    = false
 
   vnets = {
     vclst01m = {
       vlan_id     = 200
-      description = "Cluster management network - node 1"
+      description = "Cluster management network"
       subnets = {
         cluster = {
           cidr    = "10.200.0.0/24"
           gateway = "10.200.0.1"
-
-          # DHCP enabled implicitly because ranges are set
-          dhcp_range_start = "10.200.0.120"
-          dhcp_range_end   = "10.200.0.220"
-          dhcp_dns_server  = "8.8.8.8"
         }
       }
     }
@@ -62,45 +52,3 @@ module "sdn_node1" {
   proxmox_token    = var.proxmox_token
   proxmox_insecure = var.proxmox_insecure
 }
-
-# Planned future usage once the module supports multi-node inputs.
-# Intentionally commented out for the 0.1.x line.
-#
-# module "sdn_node2" {
-#   source = "../.."
-#
-#   zone_name   = "clust01"
-#   zone_bridge = "vmbr0"
-#
-#   proxmox_node = var.proxmox_node2
-#   proxmox_host = var.proxmox_host_node2
-#
-#   enable_host_l3   = true
-#   enable_snat      = true
-#   uplink_interface = "vmbr0"
-#   enable_dhcp      = true
-#
-#   dns_domain = "hybridops.local"
-#   dns_lease  = "24h"
-#
-#   vnets = {
-#     vclst02m = {
-#       vlan_id     = 200
-#       description = "Cluster management network - node 2"
-#       subnets = {
-#         cluster = {
-#           cidr    = "10.200.0.0/24"
-#           gateway = "10.200.0.1"
-#
-#           dhcp_range_start = "10.200.0.120"
-#           dhcp_range_end   = "10.200.0.220"
-#           dhcp_dns_server  = "8.8.8.8"
-#         }
-#       }
-#     }
-#   }
-#
-#   proxmox_url      = var.proxmox_url
-#   proxmox_token    = var.proxmox_token
-#   proxmox_insecure = var.proxmox_insecure
-# }

--- a/examples/multi-node/outputs.tf
+++ b/examples/multi-node/outputs.tf
@@ -1,20 +1,11 @@
 # file: outputs.tf
-# purpose: Expose SDN outputs for the node1 example
+# purpose: Expose SDN outputs for the shared cluster zone
 
-output "sdn_nodes" {
-  description = "Aggregated SDN outputs for all nodes in this example."
+output "sdn_cluster" {
+  description = "SDN objects shared by the configured Proxmox cluster nodes."
   value = {
-    node1 = {
-      zone_name = module.sdn_node1.zone_name
-      vnets     = module.sdn_node1.vnets
-      subnets   = module.sdn_node1.subnets
-    }
-
-    # Uncomment when sdn_node2 is enabled
-    # node2 = {
-    #   zone_name = module.sdn_node2.zone_name
-    #   vnets     = module.sdn_node2.vnets
-    #   subnets   = module.sdn_node2.subnets
-    # }
+    zone_name = module.sdn_cluster.zone_name
+    vnets     = module.sdn_cluster.vnets
+    subnets   = module.sdn_cluster.subnets
   }
 }

--- a/examples/multi-node/terraform.tfvars.example
+++ b/examples/multi-node/terraform.tfvars.example
@@ -6,10 +6,8 @@ proxmox_url      = "https://<PROXMOX-IP>:8006/api2/json"
 proxmox_token    = "root@pam!terraform=<YOUR-API-TOKEN-SECRET>"
 proxmox_insecure = true
 
-# Node 1 configuration
-proxmox_node1      = "<NODE1-NAME>"  # e.g. "pve-node1"
-proxmox_host_node1 = "<NODE1-IP>"    # e.g. "192.168.1.10"
+# Cluster-wide SDN membership
+proxmox_nodes = ["<NODE1-NAME>", "<NODE2-NAME>", "<NODE3-NAME>"]
 
-# Node 2 configuration – planned (when multi-node support is added)
-# proxmox_node2      = "<NODE2-NAME>"
-# proxmox_host_node2 = "<NODE2-IP>"
+# One reachable cluster node for SSH-based SDN apply and status operations
+proxmox_host = "<NODE1-IP>"

--- a/examples/multi-node/variables.tf
+++ b/examples/multi-node/variables.tf
@@ -15,24 +15,12 @@ variable "proxmox_insecure" {
   default     = true
 }
 
-variable "proxmox_node1" {
-  description = "Primary Proxmox node name (e.g., pve or hybridhub)"
-  type        = string
+variable "proxmox_nodes" {
+  description = "Proxmox node names that should share the SDN zone"
+  type        = list(string)
 }
 
-variable "proxmox_host_node1" {
-  description = "Primary Proxmox node IP for SSH"
+variable "proxmox_host" {
+  description = "One Proxmox cluster node used for SSH-based SDN apply and status operations"
   type        = string
-}
-
-variable "proxmox_node2" {
-  description = "Secondary Proxmox node name (planned / optional)"
-  type        = string
-  default     = ""
-}
-
-variable "proxmox_host_node2" {
-  description = "Secondary Proxmox node IP for SSH (planned / optional)"
-  type        = string
-  default     = ""
 }

--- a/main.tf
+++ b/main.tf
@@ -2,6 +2,10 @@
 # maintainer: HybridOps
 
 locals {
+  proxmox_nodes_effective = length(var.proxmox_nodes) > 0 ? [
+    for node in var.proxmox_nodes : trimspace(node)
+  ] : compact([trimspace(var.proxmox_node)])
+
   subnets_flat = merge([
     for vnet_key, vnet in var.vnets : {
       for subnet_key, subnet in vnet.subnets :
@@ -39,7 +43,7 @@ locals {
   sdn_reload_hash = sha1(jsonencode({
     zone_name        = var.zone_name
     zone_bridge      = var.zone_bridge
-    proxmox_node     = var.proxmox_node
+    proxmox_nodes    = local.proxmox_nodes_effective
     enable_host_l3   = var.enable_host_l3
     enable_snat      = var.enable_snat
     uplink_interface = var.uplink_interface
@@ -74,8 +78,20 @@ locals {
 resource "proxmox_virtual_environment_sdn_zone_vlan" "zone" {
   id     = var.zone_name
   bridge = var.zone_bridge
-  nodes  = [var.proxmox_node]
+  nodes  = local.proxmox_nodes_effective
   mtu    = 1500
+
+  lifecycle {
+    precondition {
+      condition     = length(local.proxmox_nodes_effective) > 0
+      error_message = "Set proxmox_node or provide at least one entry in proxmox_nodes."
+    }
+
+    precondition {
+      condition     = length(local.proxmox_nodes_effective) <= 1 || !var.enable_host_l3
+      error_message = "Cluster-wide proxmox_nodes membership currently requires enable_host_l3 = false; host L3, SNAT, DHCP, and static routes remain single-host features."
+    }
+  }
 
   depends_on = [null_resource.sdn_apply_finalizer]
 }

--- a/tests/node_membership.tftest.hcl
+++ b/tests/node_membership.tftest.hcl
@@ -1,0 +1,82 @@
+mock_provider "proxmox" {}
+mock_provider "null" {}
+
+variables {
+  zone_name        = "testzone"
+  zone_bridge      = "vmbr0"
+  proxmox_host     = "192.0.2.10"
+  proxmox_url      = "https://192.0.2.10:8006/api2/json"
+  proxmox_token    = "terraform@pve!sdn=test-token"
+  proxmox_insecure = true
+  enable_snat      = false
+  enable_dhcp      = false
+
+  vnets = {
+    vtest01 = {
+      vlan_id     = 200
+      description = "Test network"
+      subnets = {
+        test = {
+          cidr    = "10.200.0.0/24"
+          gateway = "10.200.0.1"
+        }
+      }
+    }
+  }
+}
+
+run "legacy_single_node_input" {
+  command = plan
+
+  variables {
+    proxmox_node   = "pve1"
+    enable_host_l3 = true
+  }
+
+  assert {
+    condition     = toset(proxmox_virtual_environment_sdn_zone_vlan.zone.nodes) == toset(["pve1"])
+    error_message = "The legacy proxmox_node input must remain the effective zone membership."
+  }
+}
+
+run "cluster_node_membership" {
+  command = plan
+
+  variables {
+    proxmox_node   = "legacy-pve"
+    proxmox_nodes  = ["pve1", "pve2", "pve3"]
+    enable_host_l3 = false
+  }
+
+  assert {
+    condition     = toset(proxmox_virtual_environment_sdn_zone_vlan.zone.nodes) == toset(["pve1", "pve2", "pve3"])
+    error_message = "proxmox_nodes must take precedence and assign every listed node to the SDN zone."
+  }
+}
+
+run "empty_effective_node_list_rejected" {
+  command = plan
+
+  variables {
+    proxmox_node   = ""
+    proxmox_nodes  = []
+    enable_host_l3 = false
+  }
+
+  expect_failures = [
+    proxmox_virtual_environment_sdn_zone_vlan.zone,
+  ]
+}
+
+run "multi_node_host_l3_rejected" {
+  command = plan
+
+  variables {
+    proxmox_nodes  = ["pve1", "pve2"]
+    enable_host_l3 = true
+  }
+
+  expect_failures = [
+    proxmox_virtual_environment_sdn_zone_vlan.zone,
+  ]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -13,8 +13,27 @@ variable "zone_bridge" {
 }
 
 variable "proxmox_node" {
-  description = "Proxmox node name for SDN zone attachment."
+  description = "Legacy single Proxmox node name for SDN zone attachment. Used when proxmox_nodes is empty."
   type        = string
+  default     = ""
+}
+
+variable "proxmox_nodes" {
+  description = "Optional Proxmox node names for cluster-wide SDN zone membership. Takes precedence over proxmox_node when set."
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition     = alltrue([for node in var.proxmox_nodes : trimspace(node) != ""])
+    error_message = "proxmox_nodes must not contain empty node names."
+  }
+
+  validation {
+    condition = length(var.proxmox_nodes) == length(distinct([
+      for node in var.proxmox_nodes : trimspace(node)
+    ]))
+    error_message = "proxmox_nodes must not contain duplicate node names."
+  }
 }
 
 variable "proxmox_host" {


### PR DESCRIPTION
## Summary

Closes #26

- add an optional node list for SDN zone membership
- preserve the existing single-node input
- update the multi-node example and README

## Scope

This change affects Proxmox SDN zone membership only. Host-side L3, SNAT, DHCP, static routes, and SSH targeting remain single-host.

## Validation

- `terraform fmt -recursive`
- `terraform init -backend=false -input=false`
- `terraform validate -no-color`
- `terraform test -no-color`
- validated `examples/basic`
- validated `examples/multi-node`
