### PR TITLE
feat(validation): catch invalid Proxmox SDN naming at plan time

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ module "sdn" {
   source  = "hybridops-tech/sdn/proxmox"
   version = "~> 0.1.5"
 
-  # SDN zone ID must follow Proxmox SDN rules (<= 8 chars, no dashes)
+  # SDN zone ID must follow Proxmox SDN rules (2-8 chars, must start with a letter, letters and digits only (Proxmox SDN IDconstrainto))
   zone_name    = "hybzone"
   proxmox_node = var.proxmox_node
   proxmox_host = var.proxmox_host
@@ -177,7 +177,7 @@ Typical reference layout (six VLANs):
 
 | Name           | Type   | Required | Description |
 |----------------|--------|----------|-------------|
-| `zone_name`    | string | yes      | SDN zone ID (≤ 8 chars, lowercase, no dashes – Proxmox SDN rules). |
+| `zone_name`    | string | yes      | SDN zone ID (2-8 chars, must start with a letter, letters and digits only (Proxmox SDN ID constraint)). |
 | `zone_bridge`  | string | no       | Proxmox bridge to attach the SDN zone to (default: `vmbr0`). |
 | `proxmox_node` | string | yes      | Proxmox node name (for example `pve` or `hybridhub`). |
 | `proxmox_host` | string | yes      | Proxmox host (IP or DNS) used over SSH for host-side scripts. |
@@ -246,7 +246,7 @@ route handoff.
 
 ### VNet structure
 
-Each VNet key must be a valid Proxmox SDN identifier (≤ 8 chars, no dashes).
+Each VNet key must be a valid Proxmox SDN identifier (2-8 chars, must start with a letter, letters and digits only (Proxmox SDN ID constraint)).
 
 ```hcl
 vnets = {
@@ -430,7 +430,7 @@ Destroy is still disruptive for the zone it manages, so reserve it for:
 
 ## Known limitations
 
-- SDN zone and VNet IDs must follow **Proxmox SDN naming rules** (≤ 8 chars, no dashes).
+- SDN zone and VNet IDs must follow **Proxmox SDN naming rules** (2-8 chars, must start with a letter, letters and digits only (Proxmox SDN ID constraint)).
 - After `destroy`, VNet bridge interfaces may persist until networking is reloaded (`ifreload -a` / `pvesh set /cluster/sdn`).
 - `dnsmasq` is the only supported DHCP engine.
 - On older releases, Proxmox UI may show SDN status warnings even when traffic

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ module "sdn" {
   source  = "hybridops-tech/sdn/proxmox"
   version = "~> 0.1.5"
 
-  # SDN zone ID must follow Proxmox SDN rules (2-8 chars, must start with a letter, letters and digits only (Proxmox SDN IDconstraint)
+  # SDN zone ID must follow Proxmox SDN rules (2-8 chars, must start with a letter, letters and digits only - Proxmox SDN ID constraint)
   zone_name    = "hybzone"
   proxmox_node = var.proxmox_node
   proxmox_host = var.proxmox_host
@@ -177,7 +177,7 @@ Typical reference layout (six VLANs):
 
 | Name           | Type   | Required | Description |
 |----------------|--------|----------|-------------|
-| `zone_name`    | string | yes      | SDN zone ID (2-8 chars, must start with a letter, letters and digits only (Proxmox SDN ID constraint)). |
+| `zone_name`    | string | yes      | SDN zone ID (2-8 chars, must start with a letter, letters and digits only - Proxmox SDN ID constraint). |
 | `zone_bridge`  | string | no       | Proxmox bridge to attach the SDN zone to (default: `vmbr0`). |
 | `proxmox_node` | string | yes      | Proxmox node name (for example `pve` or `hybridhub`). |
 | `proxmox_host` | string | yes      | Proxmox host (IP or DNS) used over SSH for host-side scripts. |
@@ -246,7 +246,7 @@ route handoff.
 
 ### VNet structure
 
-Each VNet key must be a valid Proxmox SDN identifier (2-8 chars, must start with a letter, letters and digits only (Proxmox SDN ID constraint)).
+Each VNet key must be a valid Proxmox SDN identifier (2-8 chars, must start with a letter, letters and digits only - Proxmox SDN ID constraint).
 
 ```hcl
 vnets = {
@@ -430,7 +430,7 @@ Destroy is still disruptive for the zone it manages, so reserve it for:
 
 ## Known limitations
 
-- SDN zone and VNet IDs must follow **Proxmox SDN naming rules** (2-8 chars, must start with a letter, letters and digits only (Proxmox SDN ID constraint)).
+- SDN zone and VNet IDs must follow **Proxmox SDN naming rules** (2-8 chars, must start with a letter, letters and digits only - Proxmox SDN ID constraint).
 - After `destroy`, VNet bridge interfaces may persist until networking is reloaded (`ifreload -a` / `pvesh set /cluster/sdn`).
 - `dnsmasq` is the only supported DHCP engine.
 - On older releases, Proxmox UI may show SDN status warnings even when traffic

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ module "sdn" {
   source  = "hybridops-tech/sdn/proxmox"
   version = "~> 0.1.5"
 
-  # SDN zone ID must follow Proxmox SDN rules (2-8 chars, must start with a letter, letters and digits only (Proxmox SDN IDconstrainto))
+  # SDN zone ID must follow Proxmox SDN rules (2-8 chars, must start with a letter, letters and digits only (Proxmox SDN IDconstraint)
   zone_name    = "hybzone"
   proxmox_node = var.proxmox_node
   proxmox_host = var.proxmox_host

--- a/tests/naming_validation.tftest.hcl
+++ b/tests/naming_validation.tftest.hcl
@@ -1,0 +1,227 @@
+# tests/naming_validation.tftest.hcl
+#
+# Covers PR review feedback: valid ID, excessive length, dash/underscore,
+# leading digit, one-character ID, and confirms that subnet keys (a local
+# Terraform map key, not a Proxmox object ID) remain unrestricted.
+
+provider "proxmox" {
+  endpoint  = var.proxmox_url
+  api_token = var.proxmox_token
+  insecure  = true
+}
+
+variables {
+  proxmox_node            = "test-node"
+  proxmox_host            = "10.0.0.1"
+  proxmox_url             = "https://10.0.0.1:8006/api2/json"
+  proxmox_token           = "user@pam!test=dummy"
+  dhcp_default_start_host = 120
+  dhcp_default_end_host   = 220
+
+  # Baseline valid vnets, reused across zone_name-focused runs.
+  vnets = {
+    vnetmgmt = {
+      vlan_id     = 10
+      description = "test"
+      subnets = {
+        subnet_name = {
+          cidr    = "10.10.0.0/24"
+          gateway = "10.10.0.1"
+        }
+      }
+    }
+  }
+}
+
+# ---- zone_name ----
+
+run "zone_name_valid" {
+  command = plan
+  variables {
+    zone_name = "hybzone"
+  }
+}
+
+run "zone_name_too_long" {
+  command = plan
+  variables {
+    zone_name = "hybzonelong" # 11 chars
+  }
+  expect_failures = [var.zone_name]
+}
+
+run "zone_name_dash" {
+  command = plan
+  variables {
+    zone_name = "hyb-zone"
+  }
+  expect_failures = [var.zone_name]
+}
+
+run "zone_name_underscore" {
+  command = plan
+  variables {
+    zone_name = "hyb_zone"
+  }
+  expect_failures = [var.zone_name]
+}
+
+run "zone_name_leading_digit" {
+  command = plan
+  variables {
+    zone_name = "1hybzon"
+  }
+  expect_failures = [var.zone_name]
+}
+
+run "zone_name_one_char" {
+  command = plan
+  variables {
+    zone_name = "h"
+  }
+  expect_failures = [var.zone_name]
+}
+
+# ---- vnets (VNet keys) ----
+
+run "vnet_key_valid" {
+  command = plan
+  variables {
+    zone_name = "hybzone"
+    vnets = {
+      vnetmgmt = {
+        vlan_id     = 10
+        description = "test"
+        subnets = {
+          subnet_name = {
+            cidr    = "10.10.0.0/24"
+            gateway = "10.10.0.1"
+          }
+        }
+      }
+    }
+  }
+}
+
+run "vnet_key_too_long" {
+  command = plan
+  variables {
+    zone_name = "hybzone"
+    vnets = {
+      vnetmgmttoolong = {
+        vlan_id     = 10
+        description = "test"
+        subnets = {
+          subnet_name = {
+            cidr    = "10.10.0.0/24"
+            gateway = "10.10.0.1"
+          }
+        }
+      }
+    }
+  }
+  expect_failures = [var.vnets]
+}
+
+run "vnet_key_dash" {
+  command = plan
+  variables {
+    zone_name = "hybzone"
+    vnets = {
+      "vnet-1" = {
+        vlan_id     = 10
+        description = "test"
+        subnets = {
+          subnet_name = {
+            cidr    = "10.10.0.0/24"
+            gateway = "10.10.0.1"
+          }
+        }
+      }
+    }
+  }
+  expect_failures = [var.vnets]
+}
+
+run "vnet_key_underscore" {
+  command = plan
+  variables {
+    zone_name = "hybzone"
+    vnets = {
+      "vnet_1" = {
+        vlan_id     = 10
+        description = "test"
+        subnets = {
+          subnet_name = {
+            cidr    = "10.10.0.0/24"
+            gateway = "10.10.0.1"
+          }
+        }
+      }
+    }
+  }
+  expect_failures = [var.vnets]
+}
+
+run "vnet_key_leading_digit" {
+  command = plan
+  variables {
+    zone_name = "hybzone"
+    vnets = {
+      "1vnet" = {
+        vlan_id     = 10
+        description = "test"
+        subnets = {
+          subnet_name = {
+            cidr    = "10.10.0.0/24"
+            gateway = "10.10.0.1"
+          }
+        }
+      }
+    }
+  }
+  expect_failures = [var.vnets]
+}
+
+run "vnet_key_one_char" {
+  command = plan
+  variables {
+    zone_name = "hybzone"
+    vnets = {
+      "v" = {
+        vlan_id     = 10
+        description = "test"
+        subnets = {
+          subnet_name = {
+            cidr    = "10.10.0.0/24"
+            gateway = "10.10.0.1"
+          }
+        }
+      }
+    }
+  }
+  expect_failures = [var.vnets]
+}
+
+# ---- subnet keys: local map keys, NOT Proxmox object IDs ----
+# Must remain unrestricted.
+
+run "subnet_key_underscore_is_allowed" {
+  command = plan
+  variables {
+    zone_name = "hybzone"
+    vnets = {
+      vnetmgmt = {
+        vlan_id     = 10
+        description = "test"
+        subnets = {
+          subnet_name = {
+            cidr    = "10.10.0.0/24"
+            gateway = "10.10.0.1"
+          }
+        }
+      }
+    }
+  }
+
+}

--- a/variables.tf
+++ b/variables.tf
@@ -104,7 +104,7 @@ variable "vnets" {
   description = <<-EOT
     SDN VNets map keyed by VNet ID.
 
-    VNet keys: <= 8 chars, no dashes (e.g. vnet1, vnetA, vnet_main)
+    VNet keys: <= 8 chars, no dashes (e.g. vnet1, vnetA, vnetmgmt)
 
     Each VNet:
       - vlan_id: VLAN tag (e.g. 10, 20, 30 )

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,11 @@
 variable "zone_name" {
   description = "SDN zone name."
   type        = string
+
+  validation {
+      condition     = can(regex("^[a-zA-Z0-9]{1,8}$", var.zone_name))
+      error_message = "zone_name must be alphanumeric and at most 8 characters (Proxmox SDN zone ID constraint)."
+    }
 }
 
 variable "zone_bridge" {
@@ -99,8 +104,10 @@ variable "vnets" {
   description = <<-EOT
     SDN VNets map keyed by VNet ID.
 
+    VNet keys: <= 8 chars, no dashes (e.g. vnet1, vnetA, vnet_main)
+
     Each VNet:
-      - vlan_id: VLAN tag (e.g. 10, 20, 30)
+      - vlan_id: VLAN tag (e.g. 10, 20, 30 )
       - description: logical description
       - subnets: map keyed by subnet ID (e.g. submgmt, subdev)
 
@@ -132,6 +139,20 @@ variable "vnets" {
       dhcp_dns_server  = optional(string)
     }))
   }))
+
+  validation {
+    condition = alltrue([for k in keys(var.vnets) : can(regex("^[a-zA-Z0-9]{1,8}$", k))])
+    error_message = "Each VNet ID must be alphanumeric and at most 8 characters."
+  }
+
+  validation {
+    condition = alltrue(flatten([
+      for vnet_k, vnet in var.vnets : [
+        for subnet_k in keys(vnet.subnets) : can(regex("^[a-zA-Z0-9]{1,8}$", subnet_k))
+      ]
+    ]))
+    error_message = "Each subnet ID must be alphanumeric and at most 8 characters."
+  }
 }
 
 variable "proxmox_url" {

--- a/variables.tf
+++ b/variables.tf
@@ -142,7 +142,7 @@ variable "vnets" {
 
   validation {
     condition     = alltrue([for k in keys(var.vnets) : can(regex("^[A-Za-z][A-Za-z0-9]{1,7}$", k))])
-    error_message = "Each VNet ID must be alphanumeric and at most 8 characters."
+    error_message = "Each VNet ID must start with a letter, contain only letters and digits, and be 2-8 characters long (Proxmox SDN VNet ID constraint)."
   }
 
 }

--- a/variables.tf
+++ b/variables.tf
@@ -107,7 +107,7 @@ variable "vnets" {
     VNet keys: <= 8 chars, no dashes (e.g. vnet1, vnetA, vnetmgmt)
 
     Each VNet:
-      - vlan_id: VLAN tag (e.g. 10, 20, 30 )
+      - vlan_id: VLAN tag (e.g. 10, 20, 30)
       - description: logical description
       - subnets: map keyed by subnet ID (e.g. submgmt, subdev)
 

--- a/variables.tf
+++ b/variables.tf
@@ -6,9 +6,9 @@ variable "zone_name" {
   type        = string
 
   validation {
-      condition     = can(regex("^[a-zA-Z0-9]{1,8}$", var.zone_name))
-      error_message = "zone_name must be alphanumeric and at most 8 characters (Proxmox SDN zone ID constraint)."
-    }
+    condition     = can(regex("^[A-Za-z][A-Za-z0-9]{1,7}$", var.zone_name))
+    error_message = "zone_name must start with a letter, contain only letters and digits, and be 2-8 characters long (Proxmox SDN zone ID constraint)."
+  }
 }
 
 variable "zone_bridge" {
@@ -104,7 +104,7 @@ variable "vnets" {
   description = <<-EOT
     SDN VNets map keyed by VNet ID.
 
-    VNet keys: <= 8 chars, no dashes (e.g. vnet1, vnetA, vnetmgmt)
+    VNet keys: 2-8 chars, must start with a letter, followed by letters/digits only (e.g. vnet1, vnetA, vnetmgmt)
 
     Each VNet:
       - vlan_id: VLAN tag (e.g. 10, 20, 30)
@@ -141,18 +141,10 @@ variable "vnets" {
   }))
 
   validation {
-    condition = alltrue([for k in keys(var.vnets) : can(regex("^[a-zA-Z0-9]{1,8}$", k))])
+    condition     = alltrue([for k in keys(var.vnets) : can(regex("^[A-Za-z][A-Za-z0-9]{1,7}$", k))])
     error_message = "Each VNet ID must be alphanumeric and at most 8 characters."
   }
 
-  validation {
-    condition = alltrue(flatten([
-      for vnet_k, vnet in var.vnets : [
-        for subnet_k in keys(vnet.subnets) : can(regex("^[a-zA-Z0-9]{1,8}$", subnet_k))
-      ]
-    ]))
-    error_message = "Each subnet ID must be alphanumeric and at most 8 characters."
-  }
 }
 
 variable "proxmox_url" {


### PR DESCRIPTION
## Summary
Proxmox SDN identifiers (zone name, VNet keys) must start with a letter,
contain only letters and digits, and be 2-8 characters long as documented
in the README but not enforced by Terraform. This adds `validation` blocks
on `zone_name` and `vnets` (VNet keys) so invalid SDN IDs fail immediately
at plan time with a clear message, instead of failing late against the
live Proxmox API.

Subnet keys are local Terraform map keys, not Proxmox object IDs, and are
intentionally left unrestricted (see README's own `subnet_name` example).

Closes #12

## Validation
- `terraform fmt -recursive`, `terraform validate` pass
- `terraform test` introduce 13/13 native Terraform tests pass, covering valid IDs,
  excessive length, dash, underscore, leading digit, and one-character IDs
  for both `zone_name` and VNet keys, plus a case confirming subnet keys
  with underscores remain valid
- Checked all existing `examples/`: every `zone_name` and VNet key already
  complies

## Scope
- [x] This pull request is focused on one change.
- [x] I have not included API tokens, SSH keys, private addresses, or customer data.
- [x] I updated documentation, examples, or tests where the change needs them.
- [x] I noted whether this was validate-only, plan-only, or tested with a live Proxmox VE run. **Validate/plan/test-only** and no live Proxmox VE run.