### PR TITLE
Add fresh edge-routed mode without host login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `enable_host_orchestration` input for fresh edge-routed deployments that
+  manage Proxmox SDN objects without Proxmox host login.
+- `api-only-edge-routed` example for creating a fresh SDN zone, VNet, and subnet
+  where routing, DHCP, firewall policy, and upstream connectivity are owned by a
+  separate network layer.
 - Optional `proxmox_nodes` input for assigning one SDN zone and its VNets to
   several Proxmox cluster nodes. Multi-node membership is edge-routed; host-side
   L3, SNAT, DHCP, and static routes remain single-host features.

--- a/README.md
+++ b/README.md
@@ -12,12 +12,13 @@ It creates a VLAN-backed SDN zone, VNets, and subnets on **Proxmox VE 8.x** and 
 - Configure **gateway IPs** on VNet bridge interfaces (host L3).
 - Add **SNAT / masquerade** rules per subnet.
 - Provision **dnsmasq DHCP** pools per subnet.
+- Run fresh **edge-routed** deployments without Proxmox host login.
 - Emit a **NetBox-ready IPAM export payload** (prefixes + DHCP metadata).
 
 The two practical operating modes are:
 
 - **Host-routed**: Proxmox owns the gateway IPs, NAT, and optional DHCP. Good for bootstrap, evaluation, and smaller sites.
-- **Edge-routed**: Proxmox SDN provides segmentation, while a real edge appliance such as VyOS owns routing and DHCP.
+- **Edge-routed**: Proxmox SDN provides segmentation, while a separate routing layer owns gateways, DHCP, firewall policy, and upstream routing. Fresh edge-routed deployments can disable host login.
 
 > **Module Source**
 >
@@ -119,6 +120,47 @@ proxmox_node = "<PROXMOX-NODE-NAME>"
 proxmox_host = "<PROXMOX-IP>"
 ```
 
+### Fresh edge-routed example without host login
+
+For a fresh deployment where the Proxmox host does not own gateways, NAT, DHCP,
+or static routes, disable host orchestration:
+
+```hcl
+module "sdn" {
+  source  = "hybridops-tech/sdn/proxmox"
+  version = "~> 0.1.5"
+
+  zone_name    = "apionly"
+  proxmox_node = var.proxmox_node
+
+  enable_host_orchestration = false
+  enable_host_l3            = false
+  enable_snat               = false
+  enable_dhcp               = false
+
+  vnets = {
+    vapimgmt = {
+      vlan_id     = 210
+      description = "API-only management network"
+      subnets = {
+        mgmt = {
+          cidr    = "10.210.0.0/24"
+          gateway = "10.210.0.1"
+        }
+      }
+    }
+  }
+
+  proxmox_url      = var.proxmox_url
+  proxmox_token    = var.proxmox_token
+  proxmox_insecure = var.proxmox_insecure
+}
+```
+
+In this mode `proxmox_host` is not required. Existing host-managed deployments
+should be cleaned up before host access is removed; this mode is intended for
+fresh edge-routed use.
+
 ### GitHub source (monorepos / explicit tag pinning)
 
 For monorepos or Terragrunt-based stacks, you can pin a specific tag directly
@@ -168,7 +210,7 @@ Typical reference layout (six VLANs):
 - `dnsmasq` installed on the Proxmox node (if using DHCP).
 - Terraform **>= 1.5.0**.
 - Provider **bpg/proxmox >= 0.50.0**.
-- SSH access from the runner to the Proxmox node for host-side configuration (L3 / SNAT / DHCP).
+- Host login from the runner to the Proxmox node for host-managed configuration (L3 / SNAT / DHCP), unless `enable_host_orchestration = false` is used for a fresh edge-routed deployment.
 
 ---
 
@@ -182,13 +224,14 @@ Typical reference layout (six VLANs):
 | `zone_bridge`  | string | no       | Proxmox bridge to attach the SDN zone to (default: `vmbr0`). |
 | `proxmox_node` | string | yes, unless `proxmox_nodes` is set | Legacy single Proxmox node name (for example `pve` or `hybridhub`). |
 | `proxmox_nodes` | list(string) | no | Cluster node names for shared SDN zone membership. Takes precedence over `proxmox_node`. |
-| `proxmox_host` | string | yes      | Proxmox host (IP or DNS) used over SSH for host-side scripts. |
+| `proxmox_host` | string | yes when host orchestration is enabled | Proxmox host (IP or DNS) used for host-managed gateway, NAT, DHCP, recovery, and cleanup. |
 | `vnets`        | map    | yes      | Map of VNets and subnets (see structure below). |
 
 ### Host L3 / SNAT / DHCP toggles
 
 | Name               | Type   | Default | Description |
 |--------------------|--------|---------|-------------|
+| `enable_host_orchestration` | bool | `true` | Enable host login for gateway, NAT, DHCP, recovery, and cleanup. Disable only for fresh edge-routed deployments. |
 | `enable_host_l3`   | bool   | `true`  | Configure VNet gateway IPs on the host (required for SNAT and DHCP). |
 | `enable_snat`      | bool   | `true`  | Enable SNAT/masquerade for SDN subnets via `uplink_interface`. |
 | `uplink_interface` | string | `vmbr0` | Uplink interface used for SNAT (typically the WAN/LAN bridge). |
@@ -203,6 +246,10 @@ Typical reference layout (six VLANs):
 > `host_static_routes` also requires `enable_host_l3 = true`, because the Proxmox host must be the effective gateway for guests before these routes can influence downstream traffic.
 >
 > A `proxmox_nodes` list containing more than one node requires `enable_host_l3 = false`. Cluster-wide membership is currently edge-routed; host L3, SNAT, DHCP, and static routes remain single-host features.
+>
+> When `enable_host_orchestration = false`, also set `enable_host_l3 = false`,
+> `enable_snat = false`, `enable_dhcp = false`, and leave `host_static_routes`
+> empty. This preserves a clean fresh edge-routed mode with no host login.
 
 ### Recovery / self-heal (host-side drift)
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,6 +9,7 @@ Each example directory also includes its own `README.md` so the Terraform Regist
 | Example | Description |
 |---|---|
 | `basic` | Single VNet with DHCP (minimal configuration). |
+| `api-only-edge-routed` | Fresh edge-routed SDN zone without Proxmox host login. |
 | `homelab-six-vlans` | Six VLAN reference layout for segmented environments. |
 | `no-dhcp` | Static IP networking without DHCP. |
 | `multi-node` | Shared edge-routed SDN zone across several Proxmox cluster nodes. |
@@ -50,6 +51,9 @@ proxmox_insecure = true
 proxmox_node     = "pve"
 proxmox_host     = "PROXMOX-IP"
 ```
+
+`api-only-edge-routed` intentionally omits `proxmox_host` because host login is
+disabled for that fresh edge-routed path.
 
 Notes:
 

--- a/examples/api-only-edge-routed/README.md
+++ b/examples/api-only-edge-routed/README.md
@@ -1,0 +1,36 @@
+# API-Only Edge-Routed Example
+
+Create a Proxmox SDN zone, VNets, and subnets for a fresh edge-routed deployment
+without logging in to the Proxmox host.
+
+Use this when routing, gateways, DHCP, firewall policy, and upstream connectivity
+are owned by a separate network layer.
+
+## What it creates
+
+- SDN zone `apionly` on bridge `vmbr0`.
+- VNet `vapimgmt` using VLAN ID `210`.
+- Subnet `10.210.0.0/24` with gateway metadata `10.210.0.1`.
+
+The gateway value is kept as SDN subnet metadata. This example does not configure
+host gateway addresses, SNAT, DHCP, static routes, or host recovery.
+
+## Usage
+
+```bash
+cp terraform.tfvars.example terraform.tfvars
+terraform init -backend=false
+terraform validate
+terraform plan
+terraform apply
+```
+
+Edit `terraform.tfvars` before running `terraform plan`.
+
+## Required variables
+
+- `proxmox_url`
+- `proxmox_token`
+- `proxmox_node`
+
+`proxmox_host` is intentionally not required because host login is disabled.

--- a/examples/api-only-edge-routed/main.tf
+++ b/examples/api-only-edge-routed/main.tf
@@ -1,0 +1,51 @@
+# file: examples/api-only-edge-routed/main.tf
+# purpose: Fresh edge-routed SDN zone without Proxmox host login
+# maintainer: HybridOps
+
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    proxmox = {
+      source  = "bpg/proxmox"
+      version = ">= 0.50.0"
+    }
+  }
+}
+
+provider "proxmox" {
+  endpoint  = var.proxmox_url
+  api_token = var.proxmox_token
+  insecure  = var.proxmox_insecure
+}
+
+module "sdn" {
+  source = "../.."
+
+  zone_name   = "apionly"
+  zone_bridge = "vmbr0"
+
+  proxmox_node = var.proxmox_node
+
+  enable_host_orchestration = false
+  enable_host_l3            = false
+  enable_snat               = false
+  enable_dhcp               = false
+
+  vnets = {
+    vapimgmt = {
+      vlan_id     = 210
+      description = "API-only management network"
+      subnets = {
+        mgmt = {
+          cidr    = "10.210.0.0/24"
+          gateway = "10.210.0.1"
+        }
+      }
+    }
+  }
+
+  proxmox_url      = var.proxmox_url
+  proxmox_token    = var.proxmox_token
+  proxmox_insecure = var.proxmox_insecure
+}

--- a/examples/api-only-edge-routed/outputs.tf
+++ b/examples/api-only-edge-routed/outputs.tf
@@ -1,0 +1,17 @@
+# file: examples/api-only-edge-routed/outputs.tf
+# purpose: Expose SDN outputs for the API-only edge-routed example
+
+output "zone_name" {
+  description = "SDN zone name."
+  value       = module.sdn.zone_name
+}
+
+output "vnets" {
+  description = "Created SDN VNets."
+  value       = module.sdn.vnets
+}
+
+output "subnets" {
+  description = "Created SDN subnets."
+  value       = module.sdn.subnets
+}

--- a/examples/api-only-edge-routed/terraform.tfvars.example
+++ b/examples/api-only-edge-routed/terraform.tfvars.example
@@ -1,0 +1,10 @@
+# file: examples/api-only-edge-routed/terraform.tfvars.example
+# purpose: Example inputs for a fresh edge-routed SDN deployment without host login
+
+# Proxmox API configuration
+proxmox_url      = "https://<PROXMOX-IP>:8006/api2/json"
+proxmox_token    = "user@pam!terraform=<YOUR-API-TOKEN-SECRET>"
+proxmox_insecure = true
+
+# SDN zone membership
+proxmox_node = "<PROXMOX-NODE-NAME>"

--- a/examples/api-only-edge-routed/variables.tf
+++ b/examples/api-only-edge-routed/variables.tf
@@ -1,0 +1,21 @@
+variable "proxmox_url" {
+  description = "Proxmox API URL."
+  type        = string
+}
+
+variable "proxmox_token" {
+  description = "Proxmox API token."
+  type        = string
+  sensitive   = true
+}
+
+variable "proxmox_insecure" {
+  description = "Skip TLS verification."
+  type        = bool
+  default     = true
+}
+
+variable "proxmox_node" {
+  description = "Proxmox node name for SDN zone membership."
+  type        = string
+}

--- a/main.tf
+++ b/main.tf
@@ -2,6 +2,11 @@
 # maintainer: HybridOps
 
 locals {
+  host_orchestration_enabled = var.enable_host_orchestration
+  host_l3_enabled            = var.enable_host_orchestration && var.enable_host_l3
+  snat_enabled               = var.enable_host_orchestration && var.enable_host_l3 && var.enable_snat
+  dhcp_enabled               = var.enable_host_orchestration && var.enable_host_l3 && var.enable_dhcp
+
   proxmox_nodes_effective = length(var.proxmox_nodes) > 0 ? [
     for node in var.proxmox_nodes : trimspace(node)
   ] : compact([trimspace(var.proxmox_node)])
@@ -13,24 +18,24 @@ locals {
         vnet_id = vnet_key
 
         dhcp_enabled_effective = (
-          var.enable_host_l3 && var.enable_dhcp &&
+          local.dhcp_enabled &&
           try(subnet.dhcp_enabled, true) != false
         )
 
         dhcp_range_start_effective = (
-          (var.enable_host_l3 && var.enable_dhcp && try(subnet.dhcp_enabled, true) != false)
+          (local.dhcp_enabled && try(subnet.dhcp_enabled, true) != false)
           ? coalesce(try(subnet.dhcp_range_start, null), cidrhost(subnet.cidr, var.dhcp_default_start_host))
           : null
         )
 
         dhcp_range_end_effective = (
-          (var.enable_host_l3 && var.enable_dhcp && try(subnet.dhcp_enabled, true) != false)
+          (local.dhcp_enabled && try(subnet.dhcp_enabled, true) != false)
           ? coalesce(try(subnet.dhcp_range_end, null), cidrhost(subnet.cidr, var.dhcp_default_end_host))
           : null
         )
 
         dhcp_dns_server_effective = (
-          (var.enable_host_l3 && var.enable_dhcp && try(subnet.dhcp_enabled, true) != false)
+          (local.dhcp_enabled && try(subnet.dhcp_enabled, true) != false)
           ? coalesce(try(subnet.dhcp_dns_server, null), var.dhcp_default_dns_server)
           : null
         )
@@ -41,15 +46,16 @@ locals {
   vnet_list = join(" ", keys(var.vnets))
 
   sdn_reload_hash = sha1(jsonencode({
-    zone_name        = var.zone_name
-    zone_bridge      = var.zone_bridge
-    proxmox_nodes    = local.proxmox_nodes_effective
-    enable_host_l3   = var.enable_host_l3
-    enable_snat      = var.enable_snat
-    uplink_interface = var.uplink_interface
-    enable_dhcp      = var.enable_dhcp
-    dns_domain       = var.dns_domain
-    dns_lease        = var.dns_lease
+    zone_name                 = var.zone_name
+    zone_bridge               = var.zone_bridge
+    proxmox_nodes             = local.proxmox_nodes_effective
+    enable_host_orchestration = var.enable_host_orchestration
+    enable_host_l3            = var.enable_host_l3
+    enable_snat               = var.enable_snat
+    uplink_interface          = var.uplink_interface
+    enable_dhcp               = var.enable_dhcp
+    dns_domain                = var.dns_domain
+    dns_lease                 = var.dns_lease
     # Explicit operator-controlled nonce to force host-side reconciliation
     # (gateway/NAT/DHCP) even when topology inputs are otherwise unchanged.
     host_reconcile_nonce = var.host_reconcile_nonce
@@ -69,7 +75,7 @@ locals {
     }
   }
 
-  dhcp_subnets = (var.enable_host_l3 && var.enable_dhcp) ? {
+  dhcp_subnets = local.dhcp_enabled ? {
     for key, s in local.subnets_flat : key => s
     if s.dhcp_enabled_effective
   } : {}
@@ -90,6 +96,21 @@ resource "proxmox_virtual_environment_sdn_zone_vlan" "zone" {
     precondition {
       condition     = length(local.proxmox_nodes_effective) <= 1 || !var.enable_host_l3
       error_message = "Cluster-wide proxmox_nodes membership currently requires enable_host_l3 = false; host L3, SNAT, DHCP, and static routes remain single-host features."
+    }
+
+    precondition {
+      condition     = !var.enable_host_orchestration || trimspace(var.proxmox_host) != ""
+      error_message = "Set proxmox_host when enable_host_orchestration = true."
+    }
+
+    precondition {
+      condition = var.enable_host_orchestration || (
+        !var.enable_host_l3 &&
+        !var.enable_snat &&
+        !var.enable_dhcp &&
+        length(var.host_static_routes) == 0
+      )
+      error_message = "When enable_host_orchestration = false, disable enable_host_l3, enable_snat, enable_dhcp, and host_static_routes."
     }
   }
 
@@ -132,7 +153,7 @@ resource "proxmox_virtual_environment_sdn_applier" "apply" {
 }
 
 resource "null_resource" "gateway_setup" {
-  for_each = var.enable_host_l3 ? local.subnets_flat : {}
+  for_each = local.host_l3_enabled ? local.subnets_flat : {}
 
   triggers = {
     zone_name    = var.zone_name
@@ -179,15 +200,18 @@ resource "null_resource" "gateway_setup" {
 
 resource "null_resource" "gateway_cleanup" {
   triggers = {
-    count        = var.enable_host_l3 ? 1 : 0
-    zone_name    = var.zone_name
-    proxmox_host = var.proxmox_host
-    vnets_hash   = md5(jsonencode(var.vnets))
+    host_l3_enabled = tostring(local.host_l3_enabled)
+    zone_name       = var.zone_name
+    proxmox_host    = var.proxmox_host
+    vnets_hash      = md5(jsonencode(var.vnets))
   }
 
   provisioner "local-exec" {
     when    = destroy
     command = <<-EOT
+      if [ "${self.triggers.host_l3_enabled}" != "true" ]; then
+        exit 0
+      fi
       scp ${path.module}/scripts/cleanup/cleanup-gateway.sh root@${self.triggers.proxmox_host}:/tmp/cleanup-gateway.sh
       ssh root@${self.triggers.proxmox_host} 'chmod +x /tmp/cleanup-gateway.sh && /tmp/cleanup-gateway.sh \
         zone \
@@ -202,7 +226,7 @@ resource "null_resource" "gateway_cleanup" {
 }
 
 resource "null_resource" "host_route_setup" {
-  for_each = var.enable_host_l3 ? local.host_static_routes : {}
+  for_each = local.host_l3_enabled ? local.host_static_routes : {}
 
   triggers = {
     zone_name           = var.zone_name
@@ -244,15 +268,18 @@ resource "null_resource" "host_route_setup" {
 
 resource "null_resource" "host_route_cleanup" {
   triggers = {
-    count        = (var.enable_host_l3 && length(var.host_static_routes) > 0) ? 1 : 0
-    zone_name    = var.zone_name
-    proxmox_host = var.proxmox_host
-    routes_hash  = sha1(jsonencode(var.host_static_routes))
+    host_routes_enabled = tostring(local.host_l3_enabled && length(var.host_static_routes) > 0)
+    zone_name           = var.zone_name
+    proxmox_host        = var.proxmox_host
+    routes_hash         = sha1(jsonencode(var.host_static_routes))
   }
 
   provisioner "local-exec" {
     when    = destroy
     command = <<-EOT
+      if [ "${self.triggers.host_routes_enabled}" != "true" ]; then
+        exit 0
+      fi
       scp ${path.module}/scripts/cleanup/cleanup-static-route.sh root@${self.triggers.proxmox_host}:/tmp/cleanup-static-route.sh
       ssh root@${self.triggers.proxmox_host} 'chmod +x /tmp/cleanup-static-route.sh && /tmp/cleanup-static-route.sh \
         zone \
@@ -267,7 +294,7 @@ resource "null_resource" "host_route_cleanup" {
 }
 
 resource "null_resource" "nat_setup" {
-  for_each = (var.enable_host_l3 && var.enable_snat) ? {
+  for_each = local.snat_enabled ? {
     for k, s in local.subnets_flat : k => s
   } : {}
 
@@ -315,7 +342,7 @@ resource "null_resource" "nat_setup" {
 
 resource "null_resource" "nat_cleanup" {
   triggers = {
-    count        = (var.enable_host_l3 && var.enable_snat) ? 1 : 0
+    snat_enabled = tostring(local.snat_enabled)
     zone_name    = var.zone_name
     proxmox_host = var.proxmox_host
     vnets_hash   = md5(jsonencode(var.vnets))
@@ -324,6 +351,9 @@ resource "null_resource" "nat_cleanup" {
   provisioner "local-exec" {
     when    = destroy
     command = <<-EOT
+      if [ "${self.triggers.snat_enabled}" != "true" ]; then
+        exit 0
+      fi
       scp ${path.module}/scripts/cleanup/cleanup-nat.sh root@${self.triggers.proxmox_host}:/tmp/cleanup-nat.sh
       ssh root@${self.triggers.proxmox_host} 'chmod +x /tmp/cleanup-nat.sh && /tmp/cleanup-nat.sh \
         zone \
@@ -393,7 +423,7 @@ resource "null_resource" "dhcp_setup" {
 
 resource "null_resource" "dhcp_cleanup" {
   triggers = {
-    count        = (var.enable_host_l3 && var.enable_dhcp) ? 1 : 0
+    dhcp_enabled = tostring(local.dhcp_enabled)
     zone_name    = var.zone_name
     proxmox_host = var.proxmox_host
     vnets_hash   = md5(jsonencode(var.vnets))
@@ -402,6 +432,9 @@ resource "null_resource" "dhcp_cleanup" {
   provisioner "local-exec" {
     when    = destroy
     command = <<-EOT
+      if [ "${self.triggers.dhcp_enabled}" != "true" ]; then
+        exit 0
+      fi
       scp ${path.module}/scripts/cleanup/cleanup-dhcp.sh root@${self.triggers.proxmox_host}:/tmp/cleanup-dhcp.sh
       ssh root@${self.triggers.proxmox_host} 'chmod +x /tmp/cleanup-dhcp.sh && /tmp/cleanup-dhcp.sh \
         zone \
@@ -417,14 +450,20 @@ resource "null_resource" "dhcp_cleanup" {
 
 resource "null_resource" "sdn_reload" {
   triggers = {
-    proxmox_host = var.proxmox_host
-    config_hash  = local.sdn_reload_hash
-    vnet_list    = local.vnet_list
+    host_orchestration_enabled = tostring(local.host_orchestration_enabled)
+    proxmox_host               = var.proxmox_host
+    config_hash                = local.sdn_reload_hash
+    vnet_list                  = local.vnet_list
   }
 
   provisioner "local-exec" {
     command = <<-EOT
       # Terraform local-exec uses /bin/sh by default; keep this POSIX-sh safe.
+      if [ "${self.triggers.host_orchestration_enabled}" != "true" ]; then
+        echo "Host orchestration disabled; skipping host SDN reload."
+        exit 0
+      fi
+
       ssh -o StrictHostKeyChecking=no root@${self.triggers.proxmox_host} 'set -eu
 
         echo "Applying SDN configuration via /cluster/sdn..."
@@ -468,9 +507,10 @@ resource "null_resource" "sdn_reload" {
 
 resource "null_resource" "sdn_auto_healing" {
   triggers = {
-    proxmox_host    = var.proxmox_host
-    sdn_reload_hash = local.sdn_reload_hash
-    installer_hash  = filemd5("${path.module}/scripts/setup/install-sdn-auto-healing.sh")
+    host_orchestration_enabled = tostring(local.host_orchestration_enabled)
+    proxmox_host               = var.proxmox_host
+    sdn_reload_hash            = local.sdn_reload_hash
+    installer_hash             = filemd5("${path.module}/scripts/setup/install-sdn-auto-healing.sh")
     gateway_state_hash = sha1(jsonencode({
       for key, subnet in local.subnets_flat : key => {
         vnet_id = subnet.vnet_id
@@ -483,6 +523,11 @@ resource "null_resource" "sdn_auto_healing" {
 
   provisioner "local-exec" {
     command = <<-EOT
+      if [ "${self.triggers.host_orchestration_enabled}" != "true" ]; then
+        echo "Host orchestration disabled; skipping host recovery setup."
+        exit 0
+      fi
+
       scp ${path.module}/scripts/setup/install-sdn-auto-healing.sh root@${self.triggers.proxmox_host}:/tmp/install-sdn-auto-healing.sh
       ssh root@${self.triggers.proxmox_host} 'chmod +x /tmp/install-sdn-auto-healing.sh && /tmp/install-sdn-auto-healing.sh'
     EOT
@@ -491,6 +536,10 @@ resource "null_resource" "sdn_auto_healing" {
   provisioner "local-exec" {
     when    = destroy
     command = <<-EOT
+      if [ "${self.triggers.host_orchestration_enabled}" != "true" ]; then
+        exit 0
+      fi
+
       ssh root@${self.triggers.proxmox_host} 'set -eu
         systemctl disable --now sdn-config-watcher.path >/dev/null 2>&1 || true
         systemctl disable --now sdn-status-fix.service >/dev/null 2>&1 || true
@@ -511,12 +560,17 @@ resource "null_resource" "sdn_auto_healing" {
 
 resource "null_resource" "sdn_apply_finalizer" {
   triggers = {
-    proxmox_host = var.proxmox_host
+    host_orchestration_enabled = tostring(local.host_orchestration_enabled)
+    proxmox_host               = var.proxmox_host
   }
 
   provisioner "local-exec" {
     when    = destroy
     command = <<-EOT
+      if [ "${self.triggers.host_orchestration_enabled}" != "true" ]; then
+        exit 0
+      fi
+
       ssh root@${self.triggers.proxmox_host} 'set -u; \
         if pvesh ls /cluster/sdn >/dev/null 2>&1; then \
           if pvesh set /cluster/sdn >/dev/null 2>&1; then exit 0; fi; \

--- a/tests/api_only.tftest.hcl
+++ b/tests/api_only.tftest.hcl
@@ -1,0 +1,88 @@
+mock_provider "proxmox" {}
+mock_provider "null" {}
+
+variables {
+  zone_name        = "apionly"
+  zone_bridge      = "vmbr0"
+  proxmox_node     = "pve1"
+  proxmox_url      = "https://192.0.2.10:8006/api2/json"
+  proxmox_token    = "terraform@pve!sdn=test-token"
+  proxmox_insecure = true
+
+  vnets = {
+    vapimgmt = {
+      vlan_id     = 210
+      description = "API-only management network"
+      subnets = {
+        mgmt = {
+          cidr    = "10.210.0.0/24"
+          gateway = "10.210.0.1"
+        }
+      }
+    }
+  }
+}
+
+run "fresh_edge_routed_without_host_login" {
+  command = plan
+
+  variables {
+    proxmox_host              = ""
+    enable_host_orchestration = false
+    enable_host_l3            = false
+    enable_snat               = false
+    enable_dhcp               = false
+  }
+
+  assert {
+    condition     = null_resource.sdn_reload.triggers.host_orchestration_enabled == "false"
+    error_message = "Fresh edge-routed mode must put the host reload step into no-host-login mode."
+  }
+
+  assert {
+    condition     = null_resource.sdn_auto_healing.triggers.host_orchestration_enabled == "false"
+    error_message = "Fresh edge-routed mode must put host recovery into no-host-login mode."
+  }
+
+  assert {
+    condition     = null_resource.sdn_apply_finalizer.triggers.host_orchestration_enabled == "false"
+    error_message = "Fresh edge-routed mode must put final cleanup into no-host-login mode."
+  }
+
+  assert {
+    condition     = length(null_resource.gateway_setup) == 0
+    error_message = "Fresh edge-routed mode must not configure host gateways."
+  }
+}
+
+run "host_managed_default_still_requires_host" {
+  command = plan
+
+  variables {
+    proxmox_host              = ""
+    enable_host_orchestration = true
+    enable_host_l3            = true
+    enable_snat               = true
+    enable_dhcp               = false
+  }
+
+  expect_failures = [
+    proxmox_virtual_environment_sdn_zone_vlan.zone,
+  ]
+}
+
+run "host_features_rejected_when_host_login_disabled" {
+  command = plan
+
+  variables {
+    proxmox_host              = ""
+    enable_host_orchestration = false
+    enable_host_l3            = true
+    enable_snat               = true
+    enable_dhcp               = false
+  }
+
+  expect_failures = [
+    proxmox_virtual_environment_sdn_zone_vlan.zone,
+  ]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -37,8 +37,15 @@ variable "proxmox_nodes" {
 }
 
 variable "proxmox_host" {
-  description = "Proxmox host (hostname or IP) used for SSH-based host-side configuration."
+  description = "Proxmox host (hostname or IP) used for host-managed gateway, NAT, DHCP, recovery, and cleanup."
   type        = string
+  default     = ""
+}
+
+variable "enable_host_orchestration" {
+  description = "Enable host login for gateway, NAT, DHCP, recovery, and cleanup. Disable only for fresh edge-routed deployments."
+  type        = bool
+  default     = true
 }
 
 variable "enable_host_l3" {


### PR DESCRIPTION
## Summary

- add a fresh edge-routed path that does not require host login
- keep the existing host-managed path as the default
- add an example and tests for both paths

## Scope

This is for new edge-routed deployments only. Existing host-managed deployments keep their current behaviour. Migration from an existing host-managed setup is documented, not automated.

## Validation

- `terraform fmt -check -recursive`
- `terraform validate -no-color`
- `terraform test -no-color`
- `terraform -chdir=examples/api-only-edge-routed validate -no-color`
- `terraform -chdir=examples/basic validate -no-color`
- `terraform -chdir=examples/multi-node validate -no-color`
- `terraform -chdir=examples/no-dhcp validate -no-color`
- `terraform -chdir=examples/homelab-six-vlans validate -no-color`

Closes #31