### PR TITLE
docs: add local Terraform test workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Thank you for considering contributing to this project.
    ```
 
 3.Make your changes following the code standards below.
-4.Test with `terraform fmt`, `terraform validate`, and (where possible) an actual deployment.
+4.Test with `terraform fmt`, `terraform validate`, the root module tests, and (where possible) an actual deployment.
 5.Commit your changes:
 
    ```bash
@@ -43,6 +43,24 @@ Thank you for considering contributing to this project.
 ---
 
 ## Testing
+
+### Root module tests
+
+Run the same module tests as CI from the repository root:
+
+```bash
+terraform init -backend=false -input=false
+terraform test -no-color
+```
+
+These tests use mocked providers, so they do not require a live Proxmox
+endpoint, real credentials, or other private values.
+
+### Example validation and live testing
+
+Module tests are separate from validating the configurations under `examples/`.
+Run `terraform init -backend=false -input=false` and `terraform validate
+-no-color` inside each example directory affected by your change.
 
 Where possible, test changes against a real **Proxmox VE 8.x** node.
 

--- a/README.md
+++ b/README.md
@@ -599,5 +599,14 @@ Before opening a PR:
 
 - Run `terraform fmt`.
 - Run `terraform validate`.
+- Run the mocked root-module tests (no live Proxmox endpoint or credentials are
+  required):
+
+  ```bash
+  terraform init -backend=false -input=false
+  terraform test -no-color
+  ```
+
+- Validate changed configurations under `examples/` separately.
 - Update `examples/` if inputs or usage change.
 - Add a short entry to `CHANGELOG.md`.


### PR DESCRIPTION
## Summary

Document the root-module test commands in both contributor entry points, matching CI exactly and separating mocked module tests from example validation and optional live Proxmox testing.

Closes #43

## Validation

- `terraform fmt -check -recursive`
- `terraform init -backend=false -input=false`
- `terraform validate -no-color`
- `terraform test -no-color` — 20 passed, 0 failed
- `git diff --check`

## Scope

- [x] This pull request is focused on one change.
- [x] I have not included API tokens, SSH keys, private addresses, or customer data.
- [x] I updated documentation, examples, or tests where the change needs them.
- [x] This was validate-only with mocked module tests; no live Proxmox VE plan or apply was run.

AI-assisted contribution; I verified the documented commands against `.github/workflows/terraform-validate.yml` and ran them locally.
