### PR TITLE
chore: configure focused CodeRabbit reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,52 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+language: en-GB
+early_access: false
+
+reviews:
+  profile: chill
+  request_changes_workflow: false
+  high_level_summary: true
+  high_level_summary_in_walkthrough: true
+  changed_files_summary: true
+  review_status: true
+  review_details: false
+  poem: false
+  in_progress_fortune: false
+  enable_prompt_for_ai_agents: false
+  sequence_diagrams: false
+  slop_detection:
+    enabled: false
+  path_filters:
+    - "!**/.terraform/**"
+    - "!**/.terraform.lock.hcl"
+    - "!**/*.tfstate"
+    - "!**/*.tfstate.*"
+    - "!**/*.tfvars"
+    - "!**/*.sha256"
+    - "!dist/**"
+  path_instructions:
+    - path: "*.tf"
+      instructions: >-
+        Check provider compatibility, stable resource identity, destructive or
+        replacement-prone changes, validation coverage, and useful outputs.
+    - path: "scripts/**"
+      instructions: >-
+        Check strict shell behaviour, quoting, idempotence, bounded failure,
+        privilege assumptions, and safe cleanup.
+    - path: "examples/**"
+      instructions: >-
+        Check that examples remain deployable, contain no credentials or
+        environment-specific state, and match the public module interface.
+  auto_review:
+    enabled: true
+    auto_incremental_review: true
+    drafts: false
+    ignore_title_keywords:
+      - "WIP"
+      - "DO NOT MERGE"
+      - "[skip review]"
+    ignore_usernames:
+      - "dependabot[bot]"
+      - "github-actions[bot]"
+


### PR DESCRIPTION
## Summary

- configure advisory CodeRabbit reviews for non-draft contributor pull requests
- exclude dependency bots, Terraform state, lockfiles, and build artifacts
- focus review guidance on resource identity, lifecycle safety, scripts, and examples
- disable decorative and automatic change-request behaviour

## Validation

- validated `.coderabbit.yaml` against the current CodeRabbit schema
- `git diff --check`